### PR TITLE
changed the BaseSampleType's name property from private to protected

### DIFF
--- a/Entity/Storage/BaseSampleType.php
+++ b/Entity/Storage/BaseSampleType.php
@@ -18,7 +18,7 @@ class BaseSampleType
      * @JMS\Groups({"default"})
      * @Carbon\Searchable(name="name")
      */
-    private $name;
+    protected $name;
 
     /**
      * Set name


### PR DESCRIPTION
"private $name" changed to "protected $ name" in Carbon\ApiBundle\Entity\Storage\BaseSampleType.php

Searching on the sample-type index did not work with the old permissions. 