### PR TITLE
quick fix -- still don't fully understand what changed

### DIFF
--- a/Controller/Production/ProductionController.php
+++ b/Controller/Production/ProductionController.php
@@ -418,7 +418,7 @@ class ProductionController extends CarbonApiController
         $data = json_decode($request->getContent(), true);
         $totalOutputSamples = $data['totalOutputSamples'];
         $outputSampleDefaults = $data['outputSampleDefaults'];
-        if($outputSampleDefaults == null ){
+        if ($outputSampleDefaults == null ) {
             $outputSampleDefaults = [];
         }
 


### PR DESCRIPTION
Seems like the front end is passing null when it used to pass an empty array to the getOutputResponse in productioncontorller.php