### PR TITLE
Fixed the listener loop problem

### DIFF
--- a/Listener/ObjectNotificationListener.php
+++ b/Listener/ObjectNotificationListener.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use Carbon\ApiBundle\Entity\EntityDetail;
 
 use Carbon\ApiBundle\Entity\UserObjectNotification;
 
@@ -29,14 +30,17 @@ class ObjectNotificationListener
         //Example: You would not want to send notifications when notification settings were updated... //also prevents the autowatching that takes place when someone creates an object.
     public $ignoreClasses = array(
         'Carbon\ApiBundle\Entity\UserObjectNotification',
-        'Carbon\ApiBundle\Entity\EntityDetail'
+        'Carbon\ApiBundle\Entity\EntityDetail',
+        'Gedmo\Loggable\Entity\LogEntry'
     );
 
     public function postPersist(LifecycleEventArgs $args)
     {
+
         $entity = $args->getEntity();
         $em = $args->getEntityManager();
         $uow = $em->getUnitOfWork();
+
 
         if (in_array(get_class($entity), $this->ignoreClasses)) {
             return;
@@ -46,20 +50,32 @@ class ObjectNotificationListener
             return;
         }
 
-        $creatingUser = $this->tokenStorage->getToken()->getUser();
 
+        $creatingUser = $this->tokenStorage->getToken()->getUser();
 
         $entDet = $em->getRepository('Carbon\ApiBundle\Entity\EntityDetail')->findOneBy(array(
             'objectClassName' => get_class($entity)
         ));
 
-        if (!$entDet instanceof EntityDetail || $entDet->getAutoWatch() == false) { //We have chosen to populate the Entity Detail table from the front end. If the entry does not exist then we are just going to exit.
-
+        if (!$entDet instanceof EntityDetail) {
             return;
-
         }
 
         $entDetId = $entDet->getId();
+
+
+        if($entDet->getAutoWatch() == true) {
+
+            $creatingUserObjectNotification = new UserObjectNotification();
+            $creatingUserObjectNotification->setEntityId($entity->getId());
+            $creatingUserObjectNotification->setEntityDetail($entDet);
+            $creatingUserObjectNotification->setUser($creatingUser);
+            $creatingUserObjectNotification->setOnUpdate(true);
+            $creatingUserObjectNotification->setOnDelete(true);
+            $em->persist($creatingUserObjectNotification);
+            $em->flush();
+
+        }
 
         $groupObjectNotification = $em->getRepository('Carbon\ApiBundle\Entity\GroupObjectNotification') //Have not even changed this yet...
             ->findOneBy(array(
@@ -73,14 +89,6 @@ class ObjectNotificationListener
                 'entityId' => null
             ))
         ;
-
-        $creatingUserObjectNotification = new UserObjectNotification();
-        $creatingUserObjectNotification->setEntityId($entity->getId());
-        $creatingUserObjectNotification->setEntityDetail($entDet);
-        $creatingUserObjectNotification->setUser($creatingUser);
-        $creatingUserObjectNotification->setOnUpdate(true);
-        $creatingUserObjectNotification->setOnDelete(true);
-        $em->persist($creatingUserObjectNotification);
 
         $groups = array();
         if ($groupObjectNotification && $onCreateGroup = $groupObjectNotification->getOnCreateGroup()) {
@@ -99,7 +107,6 @@ class ObjectNotificationListener
         }
 
         if (!count($to) && !count($groups)) {
-            $em->flush();
             return;
         }
 
@@ -138,8 +145,6 @@ class ObjectNotificationListener
             ($entity instanceof BaseRequest) ? $entity->getAlias() : $entity->getId()
         );
 
-        $em->flush();
-
         $this->mailer->send(
             $objectDescription . ' Created',
             'CarbonApiBundle:objectNotification:create.html.twig',
@@ -153,10 +158,12 @@ class ObjectNotificationListener
             $from,
             $groups
         );
+
     }
 
     public function postUpdate(LifecycleEventArgs $args)
     {
+
         $entity = $args->getEntity();
         $em = $args->getEntityManager();
         $uow = $em->getUnitOfWork();


### PR DESCRIPTION
update cryoblock.entity_detail set auto_watch=false where id=2 

^^ needs to be run when you deploy this fix or else human specimen completions willhave the same problem that they were having last week. 

The issue is essentially that HumanSpecimen/Request listener is persisting stuff while listening to an on flush event and the objectnotificationlistener is flushing stuff while listening to the onpersist event... the two things in conjunction with one another end up creating a pretty wild loop.

It is probably also a good idea to start and stop postgres and apache when deploying this. 