### PR TITLE
 added inSamples and outSamples as transient variables on baserequest…

### DIFF
--- a/Entity/Production/BaseRequest.php
+++ b/Entity/Production/BaseRequest.php
@@ -125,6 +125,10 @@ abstract class BaseRequest extends BaseCryoblockEntity Implements BaseRequestInt
      */
     protected $pipelineStep;
 
+    // Transient;
+    public $inSamples;
+    public $outSamples;
+
     /**
      * Gets the value of alias.
      *
@@ -317,6 +321,54 @@ abstract class BaseRequest extends BaseCryoblockEntity Implements BaseRequestInt
     public function setProjects($projects)
     {
         $this->projects = $projects;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getValidStatuses()
+    {
+        return $this->validStatuses;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getInSample()
+    {
+        return $this->inSample;
+    }
+
+    /**
+     * @param mixed $inSample
+     *
+     * @return self
+     */
+    public function setInSample($inSample)
+    {
+        $this->inSample = $inSample;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOutSample()
+    {
+        return $this->outSample;
+    }
+
+    /**
+     * @param mixed $outSample
+     *
+     * @return self
+     */
+    public function setOutSample($outSample)
+    {
+        $this->outSample = $outSample;
 
         return $this;
     }


### PR DESCRIPTION
… antigen requests have samples added in a form instead of through the production controller... Since each form is either setting input or output samples it would be possible to reuse the same transient variable but I think that in the longterm it would be a good idea to make this change on all of the production requests so that we can at least support the option to add or remove smaples from completed requests